### PR TITLE
Enforce c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.0)
 project(ada_demos)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_STANDARD 14)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(catkin REQUIRED


### PR DESCRIPTION
Upgrade minimum requirements for cmake and enforce usage of c++14.
`ada_demos` uses `std::make_unique` introduced in c++14.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format code with `make format`
