### PR TITLE
Update to clang-format-6.0, fix new GCC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ add_subdirectory(cameraCalibration)
 # Formatting
 #
 include(ClangFormat)
-clang_format_setup()
+clang_format_setup(VERSION 6.0)
 
 if(CLANG_FORMAT_EXECUTABLE)
   file(GLOB_RECURSE ALL_SOURCE_FILES

--- a/feeding/include/feeding/AcquisitionAction.hpp
+++ b/feeding/include/feeding/AcquisitionAction.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACQUISITIONACTION_HPP_
 
 #include <unordered_map>
+
 #include <Eigen/Core>
 #include <dart/dart.hpp>
 

--- a/feeding/include/feeding/DataCollector.hpp
+++ b/feeding/include/feeding/DataCollector.hpp
@@ -3,6 +3,7 @@
 
 #include <fstream>
 #include <iostream>
+
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
@@ -13,6 +14,7 @@
 #include <ros/ros.h>
 #include <rosbag/bag.h>
 #include <sensor_msgs/CameraInfo.h>
+
 #include <libada/Ada.hpp>
 
 #include "feeding/FTThresholdHelper.hpp"

--- a/feeding/include/feeding/FTThresholdHelper.hpp
+++ b/feeding/include/feeding/FTThresholdHelper.hpp
@@ -2,12 +2,12 @@
 #define FEEDING_FTTHRESHOLDHELPER_HPP_
 
 #include <geometry_msgs/WrenchStamped.h>
-// TODO
-#define REWD_CONTROLLERS_FOUND
+
 #ifdef REWD_CONTROLLERS_FOUND
 #include <rewd_controllers/FTThresholdClient.hpp>
 #endif
 #include <mutex>
+
 #include <Eigen/Geometry>
 #include <ros/ros.h>
 

--- a/feeding/include/feeding/FeedingDemo.hpp
+++ b/feeding/include/feeding/FeedingDemo.hpp
@@ -5,15 +5,14 @@
 #include <aikido/planner/World.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/rviz/TSRMarker.hpp>
-
 #include <ros/ros.h>
+
 #include <libada/Ada.hpp>
 
 #include "feeding/AcquisitionAction.hpp"
 #include "feeding/FTThresholdHelper.hpp"
 #include "feeding/TargetItem.hpp"
 #include "feeding/Workspace.hpp"
-
 #include "feeding/perception/Perception.hpp"
 #include "feeding/perception/PerceptionServoClient.hpp"
 #include "feeding/ranker/TargetFoodRanker.hpp"

--- a/feeding/include/feeding/FoodItem.hpp
+++ b/feeding/include/feeding/FoodItem.hpp
@@ -5,6 +5,7 @@
 #include <aikido/perception/DetectedObject.hpp>
 #include <dart/dart.hpp>
 #include <yaml-cpp/exceptions.h>
+
 #include "feeding/AcquisitionAction.hpp"
 
 namespace feeding {
@@ -38,7 +39,7 @@ public:
   dart::dynamics::MetaSkeletonPtr getMetaSkeleton() const;
 
   AcquisitionAction const* getAction() const;
-  bool setAction(int actionNum);
+  void setAction(int actionNum);
 
   double getScore() const;
 

--- a/feeding/include/feeding/action/DetectAndMoveAboveFood.hpp
+++ b/feeding/include/feeding/action/DetectAndMoveAboveFood.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_DETECTANDMOVEABOVEFOOD_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FeedingDemo.hpp"
 #include "feeding/FoodItem.hpp"
 #include "feeding/Workspace.hpp"

--- a/feeding/include/feeding/action/FeedFoodToPerson.hpp
+++ b/feeding/include/feeding/action/FeedFoodToPerson.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_FEEDFOODTOPERSON_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FeedingDemo.hpp"
 #include "feeding/Workspace.hpp"
 #include "feeding/perception/Perception.hpp"

--- a/feeding/include/feeding/action/Grab.hpp
+++ b/feeding/include/feeding/action/Grab.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_GRAB_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/Workspace.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/action/MoveAbove.hpp
+++ b/feeding/include/feeding/action/MoveAbove.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_MOVEABOVE_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FeedingDemo.hpp"
 #include "feeding/Workspace.hpp"
 

--- a/feeding/include/feeding/action/MoveAboveFood.hpp
+++ b/feeding/include/feeding/action/MoveAboveFood.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_MOVEABOVEFOOD_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/AcquisitionAction.hpp"
 #include "feeding/FeedingDemo.hpp"
 #include "feeding/Workspace.hpp"

--- a/feeding/include/feeding/action/MoveAboveForque.hpp
+++ b/feeding/include/feeding/action/MoveAboveForque.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_MOVEABOVEFORQUE_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/Workspace.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/action/MoveDirectlyToPerson.hpp
+++ b/feeding/include/feeding/action/MoveDirectlyToPerson.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_MOVEDIRECTLYTO_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FeedingDemo.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/action/MoveInFrontOfPerson.hpp
+++ b/feeding/include/feeding/action/MoveInFrontOfPerson.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_MOVEINFRONTOFPERSON_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FeedingDemo.hpp"
 #include "feeding/Workspace.hpp"
 

--- a/feeding/include/feeding/action/MoveInto.hpp
+++ b/feeding/include/feeding/action/MoveInto.hpp
@@ -2,9 +2,12 @@
 #define FEEDING_ACTION_MOVEINTO_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/TargetItem.hpp"
 #include "feeding/Workspace.hpp"
 #include "feeding/perception/Perception.hpp"
+
+#include "feeding/FTThresholdHelper.hpp"
 
 namespace feeding {
 namespace action {

--- a/feeding/include/feeding/action/MoveOutOf.hpp
+++ b/feeding/include/feeding/action/MoveOutOf.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_MOVEOUTOF_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FTThresholdHelper.hpp"
 #include "feeding/TargetItem.hpp"
 #include "feeding/Workspace.hpp"

--- a/feeding/include/feeding/action/MoveTowardsPerson.hpp
+++ b/feeding/include/feeding/action/MoveTowardsPerson.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_MOVETOWARDSPERSON_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/Workspace.hpp"
 #include "feeding/perception/Perception.hpp"
 

--- a/feeding/include/feeding/action/PickUpFork.hpp
+++ b/feeding/include/feeding/action/PickUpFork.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_PICKUPFORK_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FTThresholdHelper.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/action/PutDownFork.hpp
+++ b/feeding/include/feeding/action/PutDownFork.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_PUTDOWNFORK_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FTThresholdHelper.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/action/Scoop.hpp
+++ b/feeding/include/feeding/action/Scoop.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_SCOOP_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/Workspace.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/action/Skewer.hpp
+++ b/feeding/include/feeding/action/Skewer.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_ACTION_SKEWER_HPP_
 
 #include <libada/Ada.hpp>
+
 #include "feeding/FTThresholdHelper.hpp"
 #include "feeding/FeedingDemo.hpp"
 #include "feeding/Workspace.hpp"

--- a/feeding/include/feeding/perception/Perception.hpp
+++ b/feeding/include/feeding/perception/Perception.hpp
@@ -2,29 +2,28 @@
 #define FEEDING_PERCEPTION_HPP_
 
 #include <memory>
+
 #include <Eigen/Dense>
 #include <aikido/perception/AssetDatabase.hpp>
 #include <aikido/perception/PoseEstimatorModule.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <geometry_msgs/Pose2D.h>
+#include <image_geometry/pinhole_camera_model.h>
+#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
 #include <ros/ros.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
 #include <tf/transform_listener.h>
+
 #include <libada/Ada.hpp>
 
 #include "feeding/FoodItem.hpp"
 #include "feeding/ranker/ShortestDistanceRanker.hpp"
 #include "feeding/ranker/TargetFoodRanker.hpp"
-
-#include <cv_bridge/cv_bridge.h>
-#include <image_geometry/pinhole_camera_model.h>
-#include <sensor_msgs/CameraInfo.h>
-#include <sensor_msgs/Image.h>
-#include <sensor_msgs/image_encodings.h>
-
-#include <opencv2/calib3d/calib3d.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
-
-#include <geometry_msgs/Pose2D.h>
 
 namespace feeding {
 

--- a/feeding/include/feeding/perception/PerceptionServoClient.hpp
+++ b/feeding/include/feeding/perception/PerceptionServoClient.hpp
@@ -2,6 +2,7 @@
 #define FEEDING_PERCEPTIONSERVOCLIENT_HPP_
 
 #include <mutex>
+
 #include <aikido/control/ros/RosTrajectoryExecutor.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
@@ -10,7 +11,9 @@
 #include <dart/dynamics/BodyNode.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
+
 #include <libada/Ada.hpp>
+
 #include "feeding/perception/Perception.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/ranker/TargetFoodRanker.hpp
+++ b/feeding/include/feeding/ranker/TargetFoodRanker.hpp
@@ -2,7 +2,9 @@
 #define FEEDING_TARGETFOODRANKER_HPP_
 
 #include <vector>
+
 #include <Eigen/Core>
+
 #include "feeding/FoodItem.hpp"
 
 namespace feeding {

--- a/feeding/include/feeding/util.hpp
+++ b/feeding/include/feeding/util.hpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <utility>
+
 #include <Eigen/Dense>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/statespace/StateSpace.hpp>
@@ -12,29 +13,30 @@
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
 #include <dart/dart.hpp>
-#include <libada/Ada.hpp>
-
 #include <ros/ros.h>
 #include <tf/transform_listener.h>
 
+#include <libada/Ada.hpp>
+
 namespace feeding {
 
-static const std::vector<std::string> FOOD_NAMES = {"apple",
-                                                    "banana",
-                                                    "bell_pepper",
-                                                    "broccoli",
-                                                    "cantaloupe",
-                                                    "carrot",
-                                                    "cauliflower",
-                                                    "celery",
-                                                    "cherry_tomato",
-                                                    "grape",
-                                                    "honeydew",
-                                                    "kiwi",
-                                                    "strawberry",
-                                                    "lettuce",
-                                                    "spinach",
-                                                    "kale"};
+static const std::vector<std::string> FOOD_NAMES
+    = {"apple",
+       "banana",
+       "bell_pepper",
+       "broccoli",
+       "cantaloupe",
+       "carrot",
+       "cauliflower",
+       "celery",
+       "cherry_tomato",
+       "grape",
+       "honeydew",
+       "kiwi",
+       "strawberry",
+       "lettuce",
+       "spinach",
+       "kale"};
 
 static const std::vector<int> BEST_ACTIONS
     = {1, 5, 1, 2, 3, 1, 3, 1, 1, 3, 3, 3, 1, 1, 2, 0};

--- a/feeding/src/DataCollector.cpp
+++ b/feeding/src/DataCollector.cpp
@@ -1,12 +1,15 @@
 #include "feeding/DataCollector.hpp"
+
+#include <iostream>
+#include <sstream>
+
 #include <boost/date_time.hpp>
 #include <boost/filesystem/path.hpp>
 #include <stdlib.h>
 #include <yaml-cpp/yaml.h>
+
 #include <libada/util.hpp>
 
-#include <iostream>
-#include <sstream>
 #include "boost/date_time/posix_time/posix_time.hpp"
 
 using ada::util::createBwMatrixForTSR;
@@ -28,12 +31,12 @@ TSR getSideViewTSR(int step)
   auto tsr = pr_tsr::getDefaultPlateTSR();
   tsr.mT0_w = robotPose.inverse()
               * createIsometry(
-                    0.425 + sin(angle) * 0.1 + cos(angle) * -0.03,
-                    0.15 - cos(angle) * 0.1 + sin(angle) * -0.03,
-                    0.05,
-                    3.58,
-                    0,
-                    angle);
+                  0.425 + sin(angle) * 0.1 + cos(angle) * -0.03,
+                  0.15 - cos(angle) * 0.1 + sin(angle) * -0.03,
+                  0.05,
+                  3.58,
+                  0,
+                  angle);
 
   tsr.mBw = createBwMatrixForTSR(0.001, 0.001, 0, 0);
   return tsr;

--- a/feeding/src/FTThresholdHelper.cpp
+++ b/feeding/src/FTThresholdHelper.cpp
@@ -1,5 +1,7 @@
 #include "feeding/FTThresholdHelper.hpp"
+
 #include <thread>
+
 #include <libada/util.hpp>
 
 #include "feeding/util.hpp"
@@ -118,6 +120,9 @@ bool FTThresholdHelper::setThresholds(FTThreshold threshold)
   return mFTThresholdClient->setThresholds(
       thresholdPair.first, thresholdPair.second);
 #endif
+
+  // Handle no rewd_controllers case as if thresholds disabled
+  return true;
 }
 
 //==============================================================================
@@ -130,6 +135,9 @@ bool FTThresholdHelper::setThresholds(double forces, double torques)
   ROS_INFO_STREAM("Set thresholds " << forces << " " << torques);
   return mFTThresholdClient->setThresholds(forces, torques);
 #endif
+
+  // Handle no rewd_controllers case as if thresholds disabled
+  return true;
 }
 
 //==============================================================================

--- a/feeding/src/FeedingDemo.cpp
+++ b/feeding/src/FeedingDemo.cpp
@@ -1,12 +1,13 @@
 #include "feeding/FeedingDemo.hpp"
-#include <aikido/rviz/TrajectoryMarker.hpp>
-#include <boost/optional.hpp>
-
-#include <libada/util.hpp>
 
 #include <fstream>
 #include <iostream>
 #include <string>
+
+#include <aikido/rviz/TrajectoryMarker.hpp>
+#include <boost/optional.hpp>
+
+#include <libada/util.hpp>
 
 #include "feeding/FoodItem.hpp"
 #include "feeding/util.hpp"
@@ -276,7 +277,7 @@ Eigen::Isometry3d FeedingDemo::getPlateEndEffectorTransform() const
       = mAda->getHand()->getEndEffectorTransform("plate").get();
   eeTransform.linear() = eeTransform.linear()
                          * Eigen::Matrix3d(Eigen::AngleAxisd(
-                               M_PI * 0.5, Eigen::Vector3d::UnitZ()));
+                             M_PI * 0.5, Eigen::Vector3d::UnitZ()));
   eeTransform.translation()
       = Eigen::Vector3d(0, 0, mPlateTSRParameters.at("height"));
 

--- a/feeding/src/FoodItem.cpp
+++ b/feeding/src/FoodItem.cpp
@@ -1,4 +1,5 @@
 #include "feeding/FoodItem.hpp"
+
 #include <yaml-cpp/exceptions.h>
 
 namespace feeding {
@@ -69,7 +70,7 @@ AcquisitionAction const* FoodItem::getAction() const
 }
 
 //==============================================================================
-bool FoodItem::setAction(int actionNum)
+void FoodItem::setAction(int actionNum)
 {
   TiltStyle tiltStyle(TiltStyle::NONE);
   // Create New Acquisition Action

--- a/feeding/src/Perception.cpp
+++ b/feeding/src/Perception.cpp
@@ -1,5 +1,7 @@
 #include "feeding/Perception.hpp"
+
 #include <aikido/perception/AssetDatabase.hpp>
+
 #include "feeding/util.hpp"
 
 namespace feeding {

--- a/feeding/src/Workspace.cpp
+++ b/feeding/src/Workspace.cpp
@@ -1,6 +1,8 @@
 #include "feeding/Workspace.hpp"
+
 #include <aikido/io/CatkinResourceRetriever.hpp>
 #include <aikido/io/util.hpp>
+
 #include <libada/util.hpp>
 
 using ada::util::createIsometry;
@@ -50,7 +52,7 @@ void Workspace::addToWorld(
 {
   Eigen::Isometry3d pose = robotPose.inverse()
                            * createIsometry(getRosParam<std::vector<double>>(
-                                 "/" + name + "/pose", mNodeHandle));
+                               "/" + name + "/pose", mNodeHandle));
   addToWorldAtPose(skeleton, name, pose);
 }
 

--- a/feeding/src/action/DetectAndMoveAboveFood.cpp
+++ b/feeding/src/action/DetectAndMoveAboveFood.cpp
@@ -1,11 +1,14 @@
 #include "feeding/action/DetectAndMoveAboveFood.hpp"
+
 #include <chrono>
 #include <thread>
+
 #include <yaml-cpp/exceptions.h>
+
 #include <libada/util.hpp>
-#include "feeding/util.hpp"
 
 #include "feeding/action/MoveAboveFood.hpp"
+#include "feeding/util.hpp"
 
 using ada::util::getRosParam;
 
@@ -52,6 +55,8 @@ std::unique_ptr<FoodItem> detectAndMoveAboveFood(
 
   bool moveAboveSuccessful = false;
 
+  std::unique_ptr<FoodItem> ret;
+
   for (auto& item : candidateItems)
   {
     // actionOverride = 5;
@@ -90,7 +95,8 @@ std::unique_ptr<FoodItem> detectAndMoveAboveFood(
     moveAboveSuccessful = true;
 
     perception->setFoodItemToTrack(item.get());
-    return std::move(item);
+    ret = std::move(item);
+    break;
   }
 
   if (!moveAboveSuccessful)
@@ -101,6 +107,8 @@ std::unique_ptr<FoodItem> detectAndMoveAboveFood(
         "help?");
     return nullptr;
   }
+
+  return ret;
 }
 } // namespace action
 } // namespace feeding

--- a/feeding/src/action/FeedFoodToPerson.cpp
+++ b/feeding/src/action/FeedFoodToPerson.cpp
@@ -1,5 +1,7 @@
 #include "feeding/action/FeedFoodToPerson.hpp"
+
 #include <libada/util.hpp>
+
 #include "feeding/action/Grab.hpp"
 #include "feeding/action/MoveAbovePlate.hpp"
 #include "feeding/action/MoveDirectlyToPerson.hpp"
@@ -240,8 +242,8 @@ void feedFoodToPerson(
     eeTransform.linear()
         = eeTransform.linear()
           * Eigen::Matrix3d(
-                Eigen::AngleAxisd(M_PI * -0.25, Eigen::Vector3d::UnitY())
-                * Eigen::AngleAxisd(M_PI * 0.25, Eigen::Vector3d::UnitX()));
+              Eigen::AngleAxisd(M_PI * -0.25, Eigen::Vector3d::UnitY())
+              * Eigen::AngleAxisd(M_PI * 0.25, Eigen::Vector3d::UnitX()));
     personTSR.mTw_e.matrix() *= eeTransform.matrix();
 
     // Actually execute movement

--- a/feeding/src/action/MoveAbove.cpp
+++ b/feeding/src/action/MoveAbove.cpp
@@ -1,5 +1,7 @@
 #include "feeding/action/MoveAbove.hpp"
+
 #include <libada/util.hpp>
+
 #include "feeding/util.hpp"
 using ada::util::createBwMatrixForTSR;
 using aikido::constraint::dart::CollisionFreePtr;

--- a/feeding/src/action/MoveAboveFood.cpp
+++ b/feeding/src/action/MoveAboveFood.cpp
@@ -1,7 +1,10 @@
 #include "feeding/action/MoveAboveFood.hpp"
+
 #include <aikido/constraint/dart/TSR.hpp>
 #include <math.h>
+
 #include <libada/util.hpp>
+
 #include "feeding/AcquisitionAction.hpp"
 #include "feeding/action/MoveAbove.hpp"
 #include "feeding/util.hpp"
@@ -81,9 +84,10 @@ bool moveAboveFood(
         = Eigen::AngleAxisd(
               rotateAngle,
               Eigen::Vector3d::UnitZ()) // Take into account action rotation
-          * Eigen::Vector3d{0,
-                            -sin(M_PI * 0.25) * heightAboveFood * 0.7,
-                            cos(M_PI * 0.25) * heightAboveFood * 0.9};
+          * Eigen::Vector3d{
+              0,
+              -sin(M_PI * 0.25) * heightAboveFood * 0.7,
+              cos(M_PI * 0.25) * heightAboveFood * 0.9};
   }
 
   return moveAbove(

--- a/feeding/src/action/MoveAboveForque.cpp
+++ b/feeding/src/action/MoveAboveForque.cpp
@@ -1,5 +1,7 @@
 #include "feeding/action/MoveAboveForque.hpp"
+
 #include <pr_tsr/plate.hpp>
+
 #include <libada/util.hpp>
 
 using ada::util::createBwMatrixForTSR;
@@ -22,9 +24,10 @@ void moveAboveForque(
   // forquePose.translation() = Eigen::Vector3d{0.57, -0.019, 0.012};
   // forquePose.linear() = Eigen::Matrix3d(Eigen::AngleAxisd(0.15,
   // Eigen::Vector3d::UnitX()));
-  forquePose.translation() = Eigen::Vector3d{forkHolderTranslation[0],
-                                             forkHolderTranslation[1],
-                                             forkHolderTranslation[2]};
+  forquePose.translation() = Eigen::Vector3d{
+      forkHolderTranslation[0],
+      forkHolderTranslation[1],
+      forkHolderTranslation[2]};
   forquePose.linear() = Eigen::Matrix3d(
       Eigen::AngleAxisd(forkHolderAngle, Eigen::Vector3d::UnitX()));
   aboveForqueTSR.mT0_w = forquePose;

--- a/feeding/src/action/MoveAbovePlate.cpp
+++ b/feeding/src/action/MoveAbovePlate.cpp
@@ -1,4 +1,5 @@
 #include "feeding/action/MoveAbovePlate.hpp"
+
 #include "feeding/action/MoveAbove.hpp"
 
 namespace feeding {

--- a/feeding/src/action/MoveDirectlyToPerson.cpp
+++ b/feeding/src/action/MoveDirectlyToPerson.cpp
@@ -1,5 +1,7 @@
 #include "feeding/action/MoveDirectlyToPerson.hpp"
+
 #include <libada/util.hpp>
+
 #include "feeding/util.hpp"
 
 using ada::util::createBwMatrixForTSR;
@@ -51,8 +53,8 @@ bool moveDirectlyToPerson(
     eeTransform.linear()
         = eeTransform.linear()
           * Eigen::Matrix3d(
-                Eigen::AngleAxisd(M_PI * -0.25, Eigen::Vector3d::UnitY())
-                * Eigen::AngleAxisd(M_PI * 0.25, Eigen::Vector3d::UnitX()));
+              Eigen::AngleAxisd(M_PI * -0.25, Eigen::Vector3d::UnitY())
+              * Eigen::AngleAxisd(M_PI * 0.25, Eigen::Vector3d::UnitX()));
     personTSR.mTw_e.matrix() *= eeTransform.matrix();
   }
   else

--- a/feeding/src/action/MoveInFrontOfPerson.cpp
+++ b/feeding/src/action/MoveInFrontOfPerson.cpp
@@ -1,5 +1,7 @@
 #include "feeding/action/MoveInFrontOfPerson.hpp"
+
 #include <libada/util.hpp>
+
 #include "feeding/util.hpp"
 
 using ada::util::createBwMatrixForTSR;

--- a/feeding/src/action/MoveInto.cpp
+++ b/feeding/src/action/MoveInto.cpp
@@ -1,11 +1,11 @@
-#include "feeding/action/PutDownFork.hpp"
+#include "feeding/action/MoveInto.hpp"
 
 #include <libada/util.hpp>
 
 #include "feeding/TargetItem.hpp"
 #include "feeding/action/MoveAbove.hpp"
-#include "feeding/action/MoveInto.hpp"
 #include "feeding/action/MoveOutOf.hpp"
+#include "feeding/action/PutDownFork.hpp"
 #include "feeding/perception/PerceptionServoClient.hpp"
 #include "feeding/util.hpp"
 

--- a/feeding/src/action/MoveTowardsPerson.cpp
+++ b/feeding/src/action/MoveTowardsPerson.cpp
@@ -1,6 +1,7 @@
 #include "feeding/action/MoveTowardsPerson.hpp"
 
 #include <libada/util.hpp>
+
 #include "feeding/perception/Perception.hpp"
 
 namespace feeding {

--- a/feeding/src/action/PickUpFork.cpp
+++ b/feeding/src/action/PickUpFork.cpp
@@ -1,4 +1,5 @@
 #include "feeding/action/PickUpFork.hpp"
+
 #include "feeding/TargetItem.hpp"
 #include "feeding/action/MoveAboveForque.hpp"
 #include "feeding/action/MoveAbovePlate.hpp"

--- a/feeding/src/action/PutDownFork.cpp
+++ b/feeding/src/action/PutDownFork.cpp
@@ -1,4 +1,5 @@
 #include "feeding/action/PutDownFork.hpp"
+
 #include "feeding/TargetItem.hpp"
 #include "feeding/action/MoveAbove.hpp"
 #include "feeding/action/MoveAboveForque.hpp"

--- a/feeding/src/action/Skewer.cpp
+++ b/feeding/src/action/Skewer.cpp
@@ -1,4 +1,7 @@
 #include "feeding/action/Skewer.hpp"
+
+#include <libada/util.hpp>
+
 #include "feeding/FeedingDemo.hpp"
 #include "feeding/action/DetectAndMoveAboveFood.hpp"
 #include "feeding/action/Grab.hpp"
@@ -6,8 +9,6 @@
 #include "feeding/action/MoveInto.hpp"
 #include "feeding/action/MoveOutOf.hpp"
 #include "feeding/util.hpp"
-
-#include <libada/util.hpp>
 
 using ada::util::getRosParam;
 

--- a/feeding/src/perception/Perception.cpp
+++ b/feeding/src/perception/Perception.cpp
@@ -1,19 +1,19 @@
 #include "feeding/perception/Perception.hpp"
-#include "feeding/util.hpp"
-
-#include <Eigen/Eigenvalues>
-#include <opencv2/core/eigen.hpp>
-#include <ros/topic.h>
 
 #include <algorithm>
+
+#include <Eigen/Eigenvalues>
 #include <aikido/perception/AssetDatabase.hpp>
 #include <aikido/perception/DetectedObject.hpp>
+#include <opencv2/core/eigen.hpp>
+#include <ros/topic.h>
 #include <tf_conversions/tf_eigen.h>
-#include <libada/util.hpp>
-
 #include <yaml-cpp/exceptions.h>
 
+#include <libada/util.hpp>
+
 #include "feeding/FoodItem.hpp"
+#include "feeding/util.hpp"
 
 using ada::util::getRosParam;
 using aikido::perception::DetectedObject;

--- a/feeding/src/perception/PerceptionServoClient.cpp
+++ b/feeding/src/perception/PerceptionServoClient.cpp
@@ -1,5 +1,7 @@
 #include "feeding/perception/PerceptionServoClient.hpp"
+
 #include <chrono>
+
 #include <aikido/constraint/Satisfied.hpp>
 #include <aikido/planner/ConfigurationToConfiguration.hpp>
 #include <aikido/planner/SnapConfigurationToConfigurationPlanner.hpp>
@@ -7,6 +9,7 @@
 #include <aikido/planner/parabolic/ParabolicTimer.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSaver.hpp>
 #include <aikido/trajectory/util.hpp>
+
 #include <libada/util.hpp>
 
 #include "feeding/util.hpp"

--- a/feeding/src/ranker/ShortestDistanceRanker.cpp
+++ b/feeding/src/ranker/ShortestDistanceRanker.cpp
@@ -1,7 +1,9 @@
 #include "feeding/ranker/ShortestDistanceRanker.hpp"
 
 #include <iterator>
+
 #include <dart/common/StlHelpers.hpp>
+
 #include "feeding/AcquisitionAction.hpp"
 #include "feeding/util.hpp"
 

--- a/feeding/src/ranker/SuccessRateRanker.cpp
+++ b/feeding/src/ranker/SuccessRateRanker.cpp
@@ -1,6 +1,7 @@
 #include "feeding/ranker/SuccessRateRanker.hpp"
 
 #include <dart/common/StlHelpers.hpp>
+
 #include "feeding/AcquisitionAction.hpp"
 
 namespace feeding {

--- a/feeding/src/ranker/TargetFoodRanker.cpp
+++ b/feeding/src/ranker/TargetFoodRanker.cpp
@@ -1,6 +1,7 @@
 #include "feeding/ranker/TargetFoodRanker.hpp"
 
 #include <algorithm>
+
 #include "feeding/util.hpp"
 
 namespace feeding {

--- a/feeding/src/util.cpp
+++ b/feeding/src/util.cpp
@@ -1,6 +1,8 @@
 #include "feeding/util.hpp"
+
 #include <algorithm>
 #include <cstdlib>
+
 #include <aikido/common/Spline.hpp>
 #include <aikido/common/StepSequence.hpp>
 #include <aikido/distance/NominalConfigurationRanker.hpp>
@@ -11,7 +13,9 @@
 #include <aikido/trajectory/Interpolated.hpp>
 #include <dart/common/StlHelpers.hpp>
 #include <tf_conversions/tf_eigen.h>
+
 #include <libada/util.hpp>
+
 #include "std_msgs/String.h"
 
 static const std::vector<double> weights = {1, 1, 0.01, 0.01, 0.01, 0.01};
@@ -380,12 +384,8 @@ double getDistance(
 //==============================================================================
 Eigen::Isometry3d getForqueTransform(tf::TransformListener& tfListener)
 {
-  /*
   return getRelativeTransform(
-    tfListener,
-    "/map",
-    "/j2n6s200_forque_end_effector");
-  */
+      tfListener, "/map", "/j2n6s200_forque_end_effector");
 }
 
 //==============================================================================

--- a/simple_perception/src/main.cpp
+++ b/simple_perception/src/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+
 #include <Eigen/Dense>
 #include <aikido/constraint/Satisfied.hpp>
 #include <aikido/perception/AssetDatabase.hpp>
@@ -9,6 +10,7 @@
 #include <boost/program_options.hpp>
 #include <dart/dart.hpp>
 #include <dart/utils/urdf/DartLoader.hpp>
+
 #include <libada/Ada.hpp>
 
 namespace po = boost::program_options;

--- a/simple_trajectories/src/main.cpp
+++ b/simple_trajectories/src/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+
 #include <Eigen/Dense>
 #include <aikido/constraint/Satisfied.hpp>
 #include <aikido/planner/World.hpp>
@@ -7,6 +8,7 @@
 #include <boost/program_options.hpp>
 #include <dart/dart.hpp>
 #include <dart/utils/urdf/DartLoader.hpp>
+
 #include <libada/Ada.hpp>
 
 namespace po = boost::program_options;

--- a/soda_grasp/src/main.cpp
+++ b/soda_grasp/src/main.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <iostream>
+
 #include <Eigen/Dense>
 #include <aikido/constraint/Satisfied.hpp>
 #include <aikido/planner/World.hpp>
@@ -9,6 +10,7 @@
 #include <dart/dart.hpp>
 #include <dart/utils/urdf/DartLoader.hpp>
 #include <pr_tsr/can.hpp>
+
 #include <libada/Ada.hpp>
 
 namespace po = boost::program_options;


### PR DESCRIPTION
Ubuntu 20.04 has a newer version of GCC, and it removes the old version of clang-format.

This updates to the newer version of clang-format (to match `aikido` at `clang-format-6.0`) and removes the warnings caught by the old version of GCC.

Additionally, it removes an unnecessary definition in `FTThresholdHellper.hpp` (a 1-line change) which causes the file to incorrectly assume rewd_controllers exists when it doesn't.

***

**Before creating a pull request**

- [ N/A ] Document new methods and classes
- [x] Format code with `make format`
