### PR TITLE
Update tutorial steps for Focal support, add README for simple_trajectories

### DIFF
--- a/feeding/README.md
+++ b/feeding/README.md
@@ -7,9 +7,19 @@ Assuming you already have `ros-$DISTRO-desktop-full` installed (as per [here](ht
 
 ```
 DISTRO=melodic
-sudo apt install libopencv-dev libblas-dev liblapack-dev libmicrohttpd-dev libeigen3-dev ros-$DISTRO-control-toolbox ros-$DISTRO-ompl ros-$DISTRO-force-torque-sensor-controller ros-$DISTRO-srdfdom python-wstool ros-$DISTRO-octomap-ros ros-$DISTRO-joint-trajectory-controller ros-$DISTRO-transmission-interface ros-$DISTRO-cv-bridge ros-$DISTRO-image-transport ros-$DISTRO-image-geometry ros-$DISTRO-diagnostic-updater ros-$DISTRO-controller-manager ros-$DISTRO-rviz python-catkin-tools
+sudo apt install libopencv-dev libblas-dev liblapack-dev libmicrohttpd-dev libeigen3-dev ros-$DISTRO-control-toolbox ros-$DISTRO-ompl ros-$DISTRO-force-torque-sensor-controller ros-$DISTRO-srdfdom python3-wstool ros-$DISTRO-octomap-ros ros-$DISTRO-joint-trajectory-controller ros-$DISTRO-transmission-interface ros-$DISTRO-cv-bridge ros-$DISTRO-image-transport ros-$DISTRO-image-geometry ros-$DISTRO-diagnostic-updater ros-$DISTRO-controller-manager ros-$DISTRO-rviz python-catkin-tools
 ```
 Replace `melodic` with the appropriate ROS version: `noetic` on 20.04 (Focal) and `kinetic` on 16.04 (Xenial).
+
+If you cannot install `python-catkin-tools` you may have to use this workaround to install directly from the source repo, for more details see [this issue](https://github.com/catkin/catkin_tools/issues/594):
+```
+pip3 install -U "git+https://github.com/catkin/catkin_tools.git#egg=catkin_tools"
+```
+
+If you are on 20.04 (Focal), you should also symlink `python` to `python3` otherwise some scripts will be unable to find the python binary, causing "No such file or directory" errors when running `roslaunch`:
+```
+sudo apt install python-is-python3
+```
 
 ### PRL Git Packages
 
@@ -40,13 +50,16 @@ Note that the current demo has only been tested on the JACO 2.
 
 ## Running the Demo in Simulation
 
-After running `catkin build` and `devel/setup.bash` on your Workspace:
+Run the following commands from your ROS workspace:
 
-1) Start 'roscore', 'rviz'
-2) `roslaunch ada_launch simulation.launch` (will put 2 simulated *cantaloupe* on the plate)
-3) `roslaunch ada_demos feeding.launch` (will quit after writing ROS parameters)
-4) `cd my_catkin_workspace/devel/bin/` and `./feeding`
-5)  In RViz, subscribe to the topic `feeding/update/InteractiveMarkers` to actually see the robot.
+1. `catkin build`
+1. `source devel/setup.bash`
+1. `roscore`
+1. `rviz`
+1. `roslaunch ada_launch simulation.launch` (will put 2 simulated *cantaloupe* on the plate)
+1. `roslaunch ada_demos feeding.launch` (will quit after writing ROS parameters)
+1. `cd my_catkin_workspace/devel/bin/` and `./feeding`
+1.  In RViz, subscribe to the topic `feeding/update/InteractiveMarkers` to actually see the robot.
 
 ## Running the Demo on the JACO 2
 

--- a/simple_trajectories/README.md
+++ b/simple_trajectories/README.md
@@ -1,0 +1,7 @@
+# simple_trajectories
+
+## Running the demo
+
+1. Follow instructions to install required packages and build as explained in [the tutorial](https://github.com/personalrobotics/ada_demos/blob/master/feeding/README.md)
+1. Start `roscore` and `rviz`
+1. `cd my_catkin_workspace/devel/bin` and `./simple_trajectories [-a]`, include `-a` flag to run in simulation


### PR DESCRIPTION
Adds some notes to the tutorial on issues I ran into getting the demo working on Focal, mostly due to change to only python3 support. Also adds a starter README for `simple_trajectories`.

--

Not really related to this PR, but wondering when you ran `simple_trajectories` last? It builds alright but this line crashes: https://github.com/personalrobotics/ada_demos/blob/68f85b799f6fa917cab40af4bb37aca53bbf1ed3/simple_trajectories/src/main.cpp#L81-L83

Unsurprising because `KunzRetimer::postprocess()` [is no longer supported](https://github.com/personalrobotics/aikido/blob/92befdfe0af887aa23bf817b372c87b3933b789c/src/planner/kunzretimer/KunzRetimer.cpp#L196-L198).

I spent a while digging around to see if I could change the use of `aikido::planner::Spline` to `aikido:planner::Trajectory` so that the supported method could be called, but there is no existing method in `aikido` to convert splines to trajectories. There was such a method but it was removed when `KunzRetimer::postprocess()` support was dropped in: https://github.com/personalrobotics/aikido/pull/511.

There are a few ways to proceed but I figured I'd touch base first.